### PR TITLE
CMake library updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,26 @@ else (PROTOBUF_FOUND)
 endif(PROTOBUF_FOUND)
 
 if(WIN32)
+    if (EXISTS "${PROJECT_SOURCE_DIR}/bamtools/lib/libbamtools.lib")
+      set(BAMTOOLS_LIBRARIES "${PROJECT_SOURCE_DIR}/bamtools/lib/libbamtools.lib")
+    else()
+      find_library(BAMTOOLS_LIBRARIES libbamtools.lib)
+    endif()
 	set(CMAKE_CXX_FLAGS "/EHsc")
 	set(WIN32_INT 1)
 else(WIN32)
+    if (EXISTS "${PROJECT_SOURCE_DIR}/bamtools/lib/libbamtools.a")
+      set(BAMTOOLS_LIBRARIES "${PROJECT_SOURCE_DIR}/bamtools/lib/libbamtools.a")
+    else()
+      find_library(BAMTOOLS_LIBRARIES libbamtools.a)
+    endif()
 	find_package(ZLIB REQUIRED)
 	set(WIN32_INT 0)
 endif(WIN32)
+
+if (NOT BAMTOOLS_LIBRARIES)
+    message(FATAL_ERROR "Could not find libbamtools")
+endif(NOT BAMTOOLS_LIBRARIES)
 
 configure_file (
   "${PROJECT_SOURCE_DIR}/src/config.h.in"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,22 +7,20 @@ endif(PROTOBUF_FOUND)
 
 add_executable(express ${sources} ${headers} ${PROTO_SOURCES} ${PROTO_HEADERS})
 
-set(LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
+set(LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${BAMTOOLS_LIBRARIES})
 
 if (GPERFTOOLS_TCMALLOC) 
    set(LIBRARIES ${LIBRARIES} "libtcmalloc_minimal.a")
 endif (GPERFTOOLS_TCMALLOC)
-
-if (WIN32)
-  set(LIBRARIES ${LIBRARIES} "${CMAKE_CURRENT_SOURCE_DIR}/../bamtools/lib/libbamtools.lib" "${CMAKE_CURRENT_SOURCE_DIR}/../win_build/zlibd.lib")
-else (WIN32)
-  set(LIBRARIES ${LIBRARIES} "${CMAKE_CURRENT_SOURCE_DIR}/../bamtools/lib/libbamtools.a" "pthread")
-endif (WIN32)
 
 if (PROTOBUF_FOUND)
   get_filename_component(PROTOBUF_LIB_DIR ${PROTOBUF_LIBRARY} DIRECTORY)
   set(LIBRARIES ${LIBRARIES} "${PROTOBUF_LIB_DIR}/libprotobuf.a")
 endif(PROTOBUF_FOUND)
 
+if (WIN32)
 target_link_libraries(express ${LIBRARIES})
+else(WIN32)
+target_link_libraries(express ${LIBRARIES} pthread rt)
+endif(WIN32)
 install(TARGETS express DESTINATION bin)


### PR DESCRIPTION
This pull requests contains a couple requested changes to the CMake files:
1. Allow the use of a previously-installed bamtools that's in another location, rather than requiring the user to download & install bamtools in the eXpress directory. I have access to a compute cluster where bamtools is installed and available via environment modules, and this method allows the user to specify the location of libbamtools.a via, e.g., the CMAKE_LIBRARY_PATH environment variable.
2. At least on CentOS 6.7, librt and libpthread are needed when linking the _express_ executable. It should hurt to include these for other *nix variants, as both libraries are specified by POSIX.
