### PR TITLE
cmake: fix linking order for gcc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ endif(PROTOBUF_FOUND)
 
 add_executable(express ${sources} ${headers} ${PROTO_SOURCES} ${PROTO_HEADERS})
 
-set(LIBRARIES ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${BAMTOOLS_LIBRARIES})
+set(LIBRARIES ${Boost_LIBRARIES} ${BAMTOOLS_LIBRARIES} ${ZLIB_LIBRARIES})
 
 if (GPERFTOOLS_TCMALLOC) 
    set(LIBRARIES ${LIBRARIES} "libtcmalloc_minimal.a")


### PR DESCRIPTION
GCC, unlike Clang, is stricter about the order that its libraries are listed during the link phase for static libraries. Since `libbamtools` depends on symbols from `libz`, `-lz` must appear after bamtools. Without this patch, express fails to build with `gcc` with the following error:

```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5  -Wall -DNDEBUG  -rdynamic CMakeFiles/express.dir/biascorrection.cpp.o CMakeFiles/express.dir/bundles.cpp.o CMakeFiles/express.dir/directiondetector.cpp.o CMakeFiles/express.dir/fragments.cpp.o CMakeFiles/express.dir/lengthdistribution.cpp.o CMakeFiles/express.dir/main.cpp.o CMakeFiles/express.dir/mapparser.cpp.o CMakeFiles/express.dir/markovmodel.cpp.o CMakeFiles/express.dir/mismatchmodel.cpp.o CMakeFiles/express.dir/robertsfilter.cpp.o CMakeFiles/express.dir/sequence.cpp.o CMakeFiles/express.dir/targets.cpp.o CMakeFiles/express.dir/threadsafety.cpp.o CMakeFiles/express.dir/alignments.pb.cc.o CMakeFiles/express.dir/targets.pb.cc.o  -o express -Wl,-Bstatic -lboost_thread-mt -lboost_system-mt -lboost_filesystem-mt -lboost_program_options-mt -lboost_date_time-mt -lboost_chrono-mt -lboost_atomic-mt -Wl,-Bdynamic -lz ../bamtools/lib/libbamtools.a -Wl,-Bstatic -lprotobuf -Wl,-Bdynamic -lpthread -lrt 
../bamtools/lib/libbamtools.a(BgzfStream_p.cpp.o): In function `BamTools::Internal::BgzfStream::DeflateBlock(int)':
BgzfStream_p.cpp:(.text+0x4a7): undefined reference to `deflateInit2_'
BgzfStream_p.cpp:(.text+0x588): undefined reference to `deflate'
BgzfStream_p.cpp:(.text+0x5aa): undefined reference to `deflateEnd'
BgzfStream_p.cpp:(.text+0x749): undefined reference to `deflateEnd'
BgzfStream_p.cpp:(.text+0x921): undefined reference to `crc32'
BgzfStream_p.cpp:(.text+0x949): undefined reference to `crc32'
../bamtools/lib/libbamtools.a(BgzfStream_p.cpp.o): In function `BamTools::Internal::BgzfStream::InflateBlock(unsigned long const&)':
BgzfStream_p.cpp:(.text+0x120e): undefined reference to `inflateInit2_'
BgzfStream_p.cpp:(.text+0x12eb): undefined reference to `inflate'
BgzfStream_p.cpp:(.text+0x130d): undefined reference to `inflateEnd'
BgzfStream_p.cpp:(.text+0x13d2): undefined reference to `inflateEnd'
BgzfStream_p.cpp:(.text+0x13f4): undefined reference to `inflateEnd'
collect2: error: ld returned 1 exit status
src/CMakeFiles/express.dir/build.make:322: recipe for target 'src/express' failed
make[2]: *** [src/express] Error 1
make[2]: Leaving directory '/tmp/express-20180730-26318-1wsxi2u/eXpress-1.5.2'
CMakeFiles/Makefile2:93: recipe for target 'src/CMakeFiles/express.dir/all' failed
make[1]: *** [src/CMakeFiles/express.dir/all] Error 2
make[1]: Leaving directory '/tmp/express-20180730-26318-1wsxi2u/eXpress-1.5.2'
Makefile:132: recipe for target 'all' failed
make: *** [all] Error 2
```

See also https://github.com/brewsci/homebrew-bio/pull/331 and discussion therein.