### PR TITLE
Fix build with gcc > 6

### DIFF
--- a/src/targets.cpp
+++ b/src/targets.cpp
@@ -113,12 +113,12 @@ double Target::sample_likelihood(bool with_pseudo,
 
   double ll = LOG_1;
   double tot_mass = mass(with_pseudo);
-  double tot_eff_len = cached_effective_length(lib.bias_table);
+  double tot_eff_len = cached_effective_length(static_cast<bool>(lib.bias_table));
   if (neighbors) {
     foreach (const Target* neighbor, *neighbors) {
       tot_mass = log_add(tot_mass, neighbor->mass(with_pseudo));
       tot_eff_len = log_add(tot_eff_len,
-                            neighbor->cached_effective_length(lib.bias_table));
+                            neighbor->cached_effective_length(static_cast<bool>(lib.bias_table)));
     }
   }
   ll += tot_mass - tot_eff_len;


### PR DESCRIPTION
Building fails with gcc > 6.   See
https://github.com/adarob/eXpress/issues/18 for details.

This commit applies the patch from the Debian package repository:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859

Closes #18